### PR TITLE
Adds properties to class definitions

### DIFF
--- a/ClassTest.js
+++ b/ClassTest.js
@@ -1460,6 +1460,35 @@ test('Specifying scope on property raises error', function(){
 	}, InvalidSyntaxFatal);
 });
 
+test('Property getter can specify a return type', function(){
+	Class.define('MyClass', {
+		myProperty: {
+			value: 10,
+			getter: ['string', true]
+		}
+	});
+	var myObject = new MyClass();
+	raises(function(){
+		myObject.get('myProperty');
+	}, InvalidReturnTypeFatal);
+	myObject.set('myProperty', 'My Value');
+	ok(myObject.get('myProperty') == 'My Value');
+});
+
+test('Property setter can specify an argument type', function(){
+	Class.define('MyClass', {
+		myProperty: {
+			setter: ['number', true]
+		}
+	});
+	var myObject = new MyClass();
+	raises(function(){
+		myObject.set('myProperty', 'ten');
+	}, InvalidArgumentTypeFatal);
+	myObject.set('myProperty', 10);
+	ok(myObject.get('myProperty') === 10);
+});
+
 test('Parent object can get property without using getter', function(){
 	Class.define('MyClass', {
 		myProperty: {
@@ -1654,6 +1683,40 @@ test('Parent object can use setter whilst inheriting object does not', function(
 	var myChild = new MyChild();
 	myChild.childSetterMethod('Child Value');
 	ok(myChild.get('myProperty') == 'Child Value');
+});
+
+test('Property getter can type hint and specify getter usage', function(){
+	Class.define('MyClass', {
+		myProperty: {
+			value: 'string',
+			getter: ['boolean', function(value){
+				return (value) ? true : false;
+			}, false]
+		},
+		'public:myGetterMethod': function(){
+			return this.get('myProperty');
+		}
+	});
+	var myObject = new MyClass();
+	ok(myObject.get('myProperty') === true);
+	ok(myObject.myGetterMethod() === 'string');
+});
+
+test('Property setter can type hint and specify setter usage', function(){
+	Class.define('MyClass', {
+		myProperty: {
+			setter: ['string', true, false]
+		},
+		'public:mySetterMethod': function(value){
+			this.set('myProperty', value);
+		}
+	});
+	var myObject = new MyClass();
+	raises(function(){
+		myObject.set('myProperty', 10);
+	}, InvalidArgumentTypeFatal);
+	myObject.mySetterMethod(10);
+	ok(myObject.get('myProperty') === 10);
 });
 
 test('Class can require a file', function(){

--- a/Property.js
+++ b/Property.js
@@ -9,7 +9,9 @@
 		ownerUsesGetter,
 		childUsesGetter,
 		ownerUserSetter,
-		childUsesSetter
+		childUsesSetter,
+		getterType,
+		setterType
 	){
 		this.name = name;
 		this.value = value;
@@ -20,6 +22,8 @@
 		this.childUsesGetter = childUsesGetter;
 		this.ownerUsesSetter = ownerUserSetter;
 		this.childUsesSetter = childUsesSetter;
+		this.getterType = getterType;
+		this.setterType = setterType;
 	};
 	
 })();


### PR DESCRIPTION
Classes can be defined using a specific syntax which allows for a
property to be defined with associated getters and setters. Both
functions are optional and can be replaced with a boolean to indicate
either a simple getter/setter (true) or no getter/setter (false).

Access control can be controlled to allow for any combination of
private/protected/public access to either the underlying property or
the getter/setter.
