### PR TITLE
Enables multi-type checking

### DIFF
--- a/src/Member/Event/Definition.js
+++ b/src/Member/Event/Definition.js
@@ -10,7 +10,7 @@
 		}
 		var signatureRegex = new RegExp(
 			'^(?:\\s+)?(public|protected)\\s+event\\s+([a-z][A-Za-z0-9]*)(?:\\s+)?' +
-			'\\(([A-Za-z0-9,.\\s\\[\\]]*)\\)(?:\\s+)?$'
+			'\\(([A-Za-z0-9,.\\s\\[\\]|]*)\\)(?:\\s+)?$'
 		);
 		var signatureMatch = signatureRegex.exec(signature);
 		if (!signatureMatch) {
@@ -25,7 +25,7 @@
 		if (signatureMatch[3] == '') return;
 		var argumentTypeIdentifiers = signatureMatch[3].replace(/\s+/g, '').split(',');
 		for (var i in argumentTypeIdentifiers) {
-			if (!argumentTypeIdentifiers[i].match(/^[A-Za-z0-9.\[\]]+$/)) {
+			if (!argumentTypeIdentifiers[i].match(/^[A-Za-z0-9.\[\]|]+$/)) {
 				throw new _.Definition.Fatal(
 					'SIGNATURE_NOT_RECOGNISED',
 					'Provided signature: ' + signature

--- a/src/Member/Method/Definition.js
+++ b/src/Member/Method/Definition.js
@@ -12,7 +12,7 @@
 			'^(?:\\s+)?(?:(static|abstract)(?:\\s+))?(?:(static|abstract)(?:\\s+))?' +
 			'(public|protected|private)\\s+(?:(static|abstract)(?:\\s+))?' +
 			'(?:(static|abstract)(?:\\s+))?([a-z][A-Za-z0-9.]*)(?:\\s+)?' +
-			'\\(([A-Za-z0-9,:.\\s\\[\\]{}?=]*)\\)\\s+->\\s+([A-Za-z0-9.[\\]]+)(?:\\s+)?$'
+			'\\(([A-Za-z0-9,:.\\s\\[\\]{}?=|]*)\\)\\s+->\\s+([A-Za-z0-9.[\\]|]+)(?:\\s+)?$'
 		);
 		var signatureMatch = signatureRegex.exec(signature);
 		if (!signatureMatch) {

--- a/src/Member/Property/Definition.js
+++ b/src/Member/Property/Definition.js
@@ -10,7 +10,7 @@
 		}
 		var signatureRegex = new RegExp(
 			'^(?:\\s+)?(public|protected|private)\\s+([A-Za-z][A-Za-z0-9.]*)\\s+' +
-			'\\((?:\\s+)?([A-Za-z\\[][A-Za-z0-9.\\]]*)(?:\\s+)?\\)(?:\\s+)?$'
+			'\\((?:\\s+)?([A-Za-z\\[][A-Za-z0-9.\\]|]*)(?:\\s+)?\\)(?:\\s+)?$'
 		);
 		var signatureMatch = signatureRegex.exec(signature);
 		if (!signatureMatch) {

--- a/src/TypeChecker.js
+++ b/src/TypeChecker.js
@@ -7,6 +7,13 @@
 		if (typeof type != 'string') {
 			throw new _.TypeChecker.Fatal('NON_STRING_TYPE_IDENTIFIER');
 		}
+		if (type.match(/\|(?![^\[]*\])/)) {
+			var types = type.split(/\|(?![^\[]*\])/);
+			for (var i = 0; i < types.length; i++) {
+				if (this.isValidType(value, types[i]) === true) return true;
+			}
+			return false;
+		}
 		if (Object.prototype.toString.call(value) == '[object Array]') {
 			var match = type.match(/^\[(.+)\]$/);
 			if (match) {

--- a/src/TypeCheckerTest.js
+++ b/src/TypeCheckerTest.js
@@ -255,6 +255,25 @@ describe('TypeChecker', function(){
 		expect(checker.isValidType({}, 'mixed')).toBe(true);
 	});
 	
+	it('will verify multi-typed argument', function(){
+		expect(checker.isValidType('string', 'string|number')).toBe(true);
+		expect(checker.isValidType(123, 'string|number')).toBe(true);
+		expect(checker.isValidType({}, 'string|number|object')).toBe(true);
+		expect(checker.isValidType(new My.Example(), 'My.Example|boolean')).toBe(true);
+		expect(checker.isValidType(true, 'My.Example|boolean')).toBe(true);
+		expect(checker.isValidType(['1', '2', '3'], '[string]|[number]')).toBe(true);
+		expect(checker.isValidType([1, 2, 3], '[string]|[number]')).toBe(true);
+		expect(checker.isValidType([1, '2', 3], '[string|number]')).toBe(true);
+	});
+	
+	it('will reject invalid multi-typed argument', function(){
+		expect(checker.isValidType(true, 'string|number')).toBe(false);
+		expect(checker.isValidType({}, 'boolean|number')).toBe(false);
+		expect(checker.isValidType({}, 'My.Example|string')).toBe(false);
+		expect(checker.isValidType([1, '2', 3], '[string]|[number]')).toBe(false);
+		expect(checker.isValidType([1, '2', true], '[string|number]')).toBe(false);
+	});
+	
 	it('can accept multiple variables to type check in one call', function(){
 		expect(checker.areValidTypes(
 			['example', 123, { key: 'value' }, ['one', 'two']],


### PR DESCRIPTION
This means that a type can now be specified as this|that meaning this
OR that. Indeed, it can be this|that|other.

This is enabled to work in method argument and return types as well as
properties and events.